### PR TITLE
Feature/travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 #
 # See eg http://docs.travis-ci.com/user/languages/cpp/
 #
+# This is much simplified (rake-free) version of the example at 
+# https://github.com/rubinius/rubinius/blob/master/.travis.yml
+#
 # Dirk Eddelbuettel, 31 Jan 2015
 
 language: cpp
@@ -16,8 +19,7 @@ before_install:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install -y automake autoconf; fi
 
 before_script:
-  - travis_retry bundle
-  - if [ $TRAVIS_OS_NAME == linux ]; then travis_retry ./boostrap; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then ./boostrap.sh; fi
 
 script: 
   - ./configure && make && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,25 @@ language: cpp
 
 compiler:
   - gcc
-#  - clang
+  - clang
 
 before_install:
   - echo $LANG
   - echo $LC_ALL
   - sudo apt-get update && sudo apt-get install -y automake autoconf
   - if [ $CXX == g++ ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; sudo apt-get update -qq; fi
-#  - if [ $CXX == clang++ ]; then sudo add-apt-repository ppa:h-rayflood/llvm; ; sudo apt-get update -qq; fi
+  - if [ $CXX == clang++ ]; then sudo add-apt-repository ppa:h-rayflood/llvm; ; sudo apt-get update -qq; fi
 
 install:
   - if [ $CXX == g++ ]; then sudo apt-get install g++-4.9; export CXX="g++-4.9"; fi
+  - if [ $CXX == clang++ ]; then sudo apt-get install clang++-3.5; export CXX="clang++-3.5"; fi
 
 before_script:
   - if [ $TRAVIS_OS_NAME == linux ]; then ./bootstrap.sh; fi
 
 script: 
-  - ./configure && make && make check
+# FIXME  - ./configure && make && make check
+  FIXME  - ./configure && make
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,9 @@ before_install:
   - echo $LC_ALL
   - sudo apt-get update && sudo apt-get install -y automake autoconf
   - if [ $CXX == g++ ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; sudo apt-get update -qq; fi
-  - if [ $CXX == clang++ ]; then sudo add-apt-repository -y ppa:h-rayflood/llvm; sudo apt-get update -qq; fi
 
 install:
   - if [ $CXX == g++ ]; then sudo apt-get install g++-4.9; export CXX="g++-4.9"; fi
-  - if [ $CXX == clang++ ]; then sudo apt-get install clang++-3.5; export CXX="clang++-3.5"; fi
 
 before_script:
   - if [ $TRAVIS_OS_NAME == linux ]; then ./bootstrap.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install -y automake autoconf; fi
 
 before_script:
-  - if [ $TRAVIS_OS_NAME == linux ]; then ./boostrap.sh; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then ./bootstrap.sh; fi
 
 script: 
   - ./configure && make && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - echo $LC_ALL
   - sudo apt-get update && sudo apt-get install -y automake autoconf
   - if [ $CXX == g++ ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; sudo apt-get update -qq; fi
-  - if [ $CXX == clang++ ]; then sudo add-apt-repository ppa:h-rayflood/llvm; ; sudo apt-get update -qq; fi
+  - if [ $CXX == clang++ ]; then sudo add-apt-repository ppa:h-rayflood/llvm; sudo apt-get update -qq; fi
 
 install:
   - if [ $CXX == g++ ]; then sudo apt-get install g++-4.9; export CXX="g++-4.9"; fi
@@ -29,7 +29,7 @@ before_script:
 
 script: 
 # FIXME  - ./configure && make && make check
-  FIXME  - ./configure && make
+  - ./configure && make
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# .travis.yml for cpuaff
+#
+# See eg http://docs.travis-ci.com/user/languages/cpp/
+#
+# Dirk Eddelbuettel, 31 Jan 2015
+
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+before_install:
+  - echo $LANG
+  - echo $LC_ALL
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install -y automake autoconf; fi
+
+before_script:
+  - travis_retry bundle
+  - if [ $TRAVIS_OS_NAME == linux ]; then travis_retry ./boostrap; fi
+
+script: 
+  - ./configure && make && make check
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+os:
+  - linux
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ compiler:
 before_install:
   - echo $LANG
   - echo $LC_ALL
-  - sudo apt-get update && sudo apt-get install -y automake autoconf; fi
+  - sudo apt-get update && sudo apt-get install -y automake autoconf
   - if [ $CXX == g++ ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; sudo apt-get update -qq; fi
+#  - if [ $CXX == clang++ ]; then sudo add-apt-repository ppa:h-rayflood/llvm; ; sudo apt-get update -qq; fi
 
 install:
-  - if [ $CXX == g++ ]; then sudo apt-get install g++-4.9; export CXX="g++-4.8"; fi
+  - if [ $CXX == g++ ]; then sudo apt-get install g++-4.9; export CXX="g++-4.9"; fi
 
 before_script:
   - if [ $TRAVIS_OS_NAME == linux ]; then ./bootstrap.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,16 @@ language: cpp
 
 compiler:
   - gcc
-  - clang
+#  - clang
 
 before_install:
   - echo $LANG
   - echo $LC_ALL
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install -y automake autoconf; fi
+  - sudo apt-get update && sudo apt-get install -y automake autoconf; fi
+  - if [ $CXX == g++ ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; sudo apt-get update -qq; fi
+
+install:
+  - if [ $CXX == g++ ]; then sudo apt-get install g++-4.9; export CXX="g++-4.8"; fi
 
 before_script:
   - if [ $TRAVIS_OS_NAME == linux ]; then ./bootstrap.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - echo $LC_ALL
   - sudo apt-get update && sudo apt-get install -y automake autoconf
   - if [ $CXX == g++ ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; sudo apt-get update -qq; fi
-  - if [ $CXX == clang++ ]; then sudo add-apt-repository ppa:h-rayflood/llvm; sudo apt-get update -qq; fi
+  - if [ $CXX == clang++ ]; then sudo add-apt-repository -y ppa:h-rayflood/llvm; sudo apt-get update -qq; fi
 
 install:
   - if [ $CXX == g++ ]; then sudo apt-get install g++-4.9; export CXX="g++-4.9"; fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+aclocal
+autoheader
+automake --add-missing
+autoconf

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+## let the Makefile help us some
+test -f Makefile && make distclean
+
+## remove autotools generated files
+rm -rf Makefile.in \
+    aclocal.m4 \
+    autom4te.cache/ \
+    compile \
+    config.guess \
+    config.h.in \
+    config.sub \
+    configure \
+    depcomp \
+    examples/Makefile.in \
+    include/Makefile.in \
+    install-sh \
+    missing \
+    test-driver \
+    tests/Makefile.in 


### PR DESCRIPTION
This adds Travis support.  And it even upgrades to g++-4.9.  

Sadly, though, it still fails -- but this may now be something for you to look at.  On my box, `configure && make && make check` works fine.

You will have to 'link' Travis and GitHub, see eg [the first few paragraphs here](http://docs.travis-ci.com/user/getting-started/).  The pull request gets you working `.travis.yml` so on new commits it will run the tests for you.   

I also added two simple helpers `bootstrap.sh` (to call the auto\* helpers) and `cleanup.sh` to remove their artifacts.
