### PR TITLE
remove unnecessary semicolon so it can build with pedantic GCC flag

### DIFF
--- a/include/cpuaff/impl/linux_impl/sysfs_reader.hpp
+++ b/include/cpuaff/impl/linux_impl/sysfs_reader.hpp
@@ -271,7 +271,7 @@ inline bool load_cpus(std::vector< pu > &pus)
 
     return !!pus.size();
 }
-};
+}
 
 }  // namespace linux_impl
 }  // namespace impl


### PR DESCRIPTION
./cpuaff/include/cpuaff/impl/linux_impl/sysfs_reader.hpp:274:2: error: extra ‘;’ [-Werror=pedantic]
